### PR TITLE
Axios is a main dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3493,7 +3493,6 @@
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
       "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
-      "dev": true,
       "requires": {
         "follow-redirects": "1.5.10"
       },
@@ -3502,7 +3501,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -3511,7 +3509,6 @@
           "version": "1.5.10",
           "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
           "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "dev": true,
           "requires": {
             "debug": "=3.1.0"
           }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "pre-commit": "npm run lint"
   },
   "dependencies": {
+    "axios": "^0.19.2",
     "bignumber.js": "^9.0.0",
     "browser-or-node": "^1.2.1",
     "core-js": "^3.4.4",
@@ -73,7 +74,6 @@
     "@vue/cli-plugin-eslint": "^4.2.3",
     "@vue/cli-service": "^4.1.0",
     "@vue/eslint-config-prettier": "^4.0.1",
-    "axios": "^0.19.2",
     "babel-core": "^7.0.0-bridge.0",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^25.1.0",


### PR DESCRIPTION
Move Axios from `devDependencies` into `dependencies`. I got the error when trying to run the latest version (`2.1.23-beta.5`) of the lib.