### PR TITLE
Fix error caused when using in Angular 12 project

### DIFF
--- a/src/connectClient/config.js
+++ b/src/connectClient/config.js
@@ -1,7 +1,7 @@
-import * as packageJSON from '../../package.json';
+import packageJson from "../../package.json";
 
 const env = 'production';
-const version = packageJSON.version;
+const { version } = packageJson;
 const V1endpoint = 'https://connect.mewapi.io';
 const V2endpoint = 'wss://connect2.mewapi.io/staging';
 


### PR DESCRIPTION
Error: Should not import the named export 'version' (imported as 'packageJSON') from default-exporting module (only default export is available soon)